### PR TITLE
Fix text vertical align in Firefox

### DIFF
--- a/src/gauge.js
+++ b/src/gauge.js
@@ -238,7 +238,8 @@
           "font-family": "sans-serif",
           "font-weight": "normal",
           "text-anchor": "middle",
-          "alignment-baseline": "middle"
+          "alignment-baseline": "middle",
+          "dominant-baseline": "central"
         });
 
         gaugeValuePath = svg("path", {


### PR DESCRIPTION
Firefox alignment-baseline property works only with:
<tspan>
<tref>
<altglyph>
<textpath>